### PR TITLE
Actually use __init__.py (and shorten imports)

### DIFF
--- a/bin/ktool
+++ b/bin/ktool
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
 
-import argparse
 import os
 import pprint
+import argparse
 
-from ktool.dyld import Dyld
-from ktool.generator import TBDGenerator, FatMachOGenerator
-from ktool.headers import HeaderGenerator
-from ktool.macho import MachOFileType, MachOFile
-from ktool.objc import ObjCLibrary
-from ktool.util import TapiYAMLWriter, log, LogLevel
+from ktool import (
+    Dyld,
+    TBDGenerator,
+    FatMachOGenerator,
+    HeaderGenerator,
+    MachOFileType,
+    MachOFile,
+    ObjCLibrary,
+    TapiYAMLWriter,
+    log,
+    LogLevel
+)
+
 from enum import Enum
 
 

--- a/src/ktool/__init__.py
+++ b/src/ktool/__init__.py
@@ -1,0 +1,7 @@
+from .dyld import *
+from .objc import *
+from .util import *
+from .macho import *
+from .headers import *
+from .structs import *
+from .generator import *

--- a/src/ktool/dyld.py
+++ b/src/ktool/dyld.py
@@ -1,12 +1,12 @@
-from .util import log
+from ktool import log
 from collections import namedtuple
 from enum import IntEnum, Enum
 
-from ktool.structs import symtab_entry_t, dyld_header, dyld_header_t, unk_command_t, dylib_command, dylib_command_t, \
+from ktool import symtab_entry_t, dyld_header, dyld_header_t, unk_command_t, dylib_command, dylib_command_t, \
     dyld_info_command, symtab_command, uuid_command, build_version_command, segment_command_64, LOAD_COMMAND_TYPEMAP, \
     sizeof, struct, sub_client_command
 
-from ktool.macho import _VirtualMemoryMap, Segment
+from ktool import _VirtualMemoryMap, Segment
 
 
 class Dyld:

--- a/src/ktool/generator.py
+++ b/src/ktool/generator.py
@@ -1,7 +1,10 @@
-from ktool.dyld import SymbolType, Dyld
-from ktool.macho import Slice
-from ktool.objc import ObjCLibrary
 import os
+from ktool import (
+    Dyld,
+    Slice,
+    SymbolType,
+    ObjCLibrary
+)
 from collections import namedtuple
 
 

--- a/src/ktool/headers.py
+++ b/src/ktool/headers.py
@@ -1,5 +1,4 @@
-from ktool.dyld import SymbolType
-from ktool.objc import ObjCLibrary
+from ktool import SymbolType, ObjCLibrary
 
 
 class HeaderUtils:

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -1,10 +1,19 @@
-import mmap
 import os
-from collections import namedtuple
+import mmap
+
 from enum import Enum
 from typing import Tuple
+from collections import namedtuple
 
-from ktool.structs import fat_header, fat_header_t, fat_arch_t, segment_command_64_t, section_64_t, sizeof, struct
+from ktool import (
+    fat_header,
+    fat_header_t,
+    fat_arch_t,
+    segment_command_64_t,
+    section_64_t,
+    sizeof,
+    struct
+)
 
 
 class MachOFileType(Enum):

--- a/src/ktool/objc.py
+++ b/src/ktool/objc.py
@@ -1,4 +1,4 @@
-from .util import log
+from ktool import log
 from enum import Enum
 
 from ktool.structs import *


### PR DESCRIPTION
This PR makes use of `__init__.py` in order make it easier to import classes from the project into and outside of the project, since this is the actual use of the file, shortening import statements.

Currently, everything provided by the module/distribution is being imported, which isn't the best practice (because there's things that shouldn't be imported(?)), so I'd like so input on that.