### PR TITLE
Small changes and fixes to test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,25 +1,33 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: tests
+name: Tests
 
 on:
   push:
-    branches: [ master, python3.10 ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+    branches:
+      - master
+      - 'develop/**'
   pull_request:
-    branches: [ master, python3.10 ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+    branches:
+      - master
+      - 'develop/**'
 
 jobs:
-  build:
-
+  run-tests:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10.0-rc.1
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10.0-rc.1
+        python-version: ${{ secrets.PYTHON_VERSION }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This PR changes the Github workflow used to run tests; small commits (such as those as simple README changes) are now ignored by the workflow, and the workflow now runs tests for changes inside branches starting with `develop/`.

Since specific Python versions will be used for development (in the future), this PR makes specfying what Python version the workflow needs to setup more dynamic — requiring a secret with the Python version to be setup before merging this. This specific change can be discussed at any point.

Specific changes made have been documented under the commit message.  