### PR TITLE
Improvements to dump --sorted

### DIFF
--- a/bin/ktool
+++ b/bin/ktool
@@ -595,8 +595,8 @@ def dump(args):
 
         if args.sort_headers:
             for objc_class in objc_lib.classlist:
-                objc_class.methods = sorted(objc_class.methods, key=lambda h: h.signature)
-                objc_class.properties = sorted(objc_class.properties, key=lambda h: h.name)
+                objc_class.methods.sort(key=lambda h: h.signature)
+                objc_class.properties.sort(key=lambda h: h.name)
 
         if args.outdir is None:
             exit_with_error(KToolError.ArgumentError,

--- a/bin/ktool
+++ b/bin/ktool
@@ -597,6 +597,12 @@ def dump(args):
             for objc_class in objc_lib.classlist:
                 objc_class.methods.sort(key=lambda h: h.signature)
                 objc_class.properties.sort(key=lambda h: h.name)
+                if objc_class.metaclass is not None:
+                    objc_class.metaclass.methods.sort(key=lambda h: h.signature)
+
+            for objc_proto in objc_lib.protolist:
+                objc_proto.methods.sort(key=lambda h: h.signature)
+                objc_proto.opt_methods.sort(key=lambda h: h.signature)
 
         if args.outdir is None:
             exit_with_error(KToolError.ArgumentError,


### PR DESCRIPTION
* Use in-place `.sort()` instead of creating a new list with `sorted()`. I don't know how much it matters for performance but I think it's more readable.
* Currently --sorted is only sorting instance methods in classes. Also sort class/static methods (methods in the metaclass) and methods in protocols.