### PR TITLE
Use last path component for library filename

### DIFF
--- a/bin/ktool
+++ b/bin/ktool
@@ -696,7 +696,7 @@ def dump(args):
         machofile = MachOFile(fd)
         library = Dyld.load(machofile.slices[args.slice_index])
         if library.name == "":
-            library.name = args.filename
+            library.name = args.filename.split("/")[-1]
         objc_lib = ObjCLibrary(library)
 
         if args.sort_headers:


### PR DESCRIPTION
This avoids an exception being thrown when writing out the umbrella header, which will otherwise contain a directory hierarchy that doesn't exist.